### PR TITLE
Fix Title spacing

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -225,7 +225,7 @@ body {
   -webkit-text-fill-color: transparent;
 }
 .Hello {
-  grid-template-columns: repeat(2, max-content);
+  grid-template-columns: repeat(2, auto);
 }
 .Hello::before {
   content: '';


### PR DESCRIPTION
grid max-content wasn't working on mobile. We just wanted grid columns to be auto