### PR TITLE
Fix Metadata header on blog pages

### DIFF
--- a/src/app/(768-container)/blog/[slug]/page.tsx
+++ b/src/app/(768-container)/blog/[slug]/page.tsx
@@ -97,7 +97,7 @@ export async function generateMetadata({
 
   return {
     title: {
-      default: 'Scotty Kaye',
+      default: `${props.frontMatter.title}`,
       template: '%s | Scotty Kaye',
     },
     description: props.frontMatter.description,


### PR DESCRIPTION
### Context

My name was repeating twice `Scotty Kaye | Scotty Kaye` I updated to `<Blog post title> | Scotty Kaye`